### PR TITLE
Add mounted checks before animating map camera

### DIFF
--- a/lib/src/widgets/place_picker.dart
+++ b/lib/src/widgets/place_picker.dart
@@ -944,7 +944,17 @@ class PlacePickerState extends State<PlacePicker>
       {AutoCompleteItem? autoCompleteResult}) async {
     _isAnimating = true;
 
+    if (!mounted) {
+      _isAnimating = false;
+      return;
+    }
+
     final controller = await mapController.future;
+
+    if (!mounted) {
+      _isAnimating = false;
+      return;
+    }
 
     await controller.animateCamera(
       CameraUpdate.newCameraPosition(


### PR DESCRIPTION
## Purpose
Fix this crash

```
          Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Bad state: GoogleMapController for map ID 2 was used after the associated GoogleMap widget had already been disposed.
#00 pc 0x706db7 com.cashtic (GoogleMapController._checkWidgetMountedOrThrow [controller.dart:441]) (BuildId: 4f1bdaedd33ceb89128a5ff3b080f7a8)
#01 pc 0x7065ff com.cashtic (GoogleMapController.animateCamera [controller.dart:282]) (BuildId: 4f1bdaedd33ceb89128a5ff3b080f7a8)
#02 pc 0xadf3db com.cashtic (PlacePickerState.animateToLocation [place_picker.dart:949]) (BuildId: 4f1bdaedd33ceb89128a5ff3b080f7a8)
```

## Summary
- add mounted checks to `animateToLocation` to avoid using a disposed `GoogleMapController`
- ensure ongoing animations are cancelled early when widget is unmounted

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bc7f4757c8331a2287c3869999458)